### PR TITLE
Correct iPython notebook selection of most recent run to sort glob results

### DIFF
--- a/telemanom/result-viewer.ipynb
+++ b/telemanom/result-viewer.ipynb
@@ -134,7 +134,9 @@
     "# print(\"Prior run: %s\" %results_fn.split(\"/\")[-1])\n",
     "\n",
     "# Default to most recent\n",
-    "results_fn = glob.glob('../results/*.csv')[-1]\n",
+    "results_fn = glob.glob('../results/*.csv')\n",
+    "results_fn.sort()\n",
+    "results_fn = results_fn[-1]\n",
     "print('Using most recent run: {}'.format(results_fn.split(\"/\")[-1]))\n",
     "\n",
     "run_id = results_fn.split(\"/\")[-1][:-4]"


### PR DESCRIPTION
I just wanted to make an edit to your iPython notebook. Apparently it didn't select the most recent run because glob.glob didn't sort the directories by names.